### PR TITLE
Fix browse-url error

### DIFF
--- a/helm-hoogle.el
+++ b/helm-hoogle.el
@@ -70,7 +70,7 @@
   (helm :sources
         (helm-build-sync-source "Hoogle"
           :candidates #'helm-c-hoogle-set-candidates
-          :action '(("Lookup Entry" browse-url))
+          :action '(("Lookup Entry" . browse-url))
           :filtered-candidate-transformer (lambda (candidates source) candidates)
           :volatile t)
         :prompt "Hoogle: "


### PR DESCRIPTION
When helm-hoogle is invoked, it gives an error "Invalid function: (browse-url)" because the structure of the action alist is incorrect. This commit fixes it, but we could also use helm-make-actions to automatically create the alist and avoid this error entirely.
